### PR TITLE
Add more supports for vsphere.

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -483,20 +483,24 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 		cluster.Spec.CloudProvider = c.Cloud
 
 		if c.Cloud == "vsphere" {
+			if cluster.Spec.CloudConfig == nil {
+				cluster.Spec.CloudConfig = &api.CloudConfiguration{}
+			}
+
 			if c.VSphereServer == "" {
 				return fmt.Errorf("vsphere-server is required for vSphere. Set vCenter URL Ex: 10.192.10.30 or myvcenter.io (without https://)")
 			}
-			cluster.Spec.VSphereServer = c.VSphereServer
+			cluster.Spec.CloudConfig.VSphereServer = c.VSphereServer
 
 			if c.VSphereDatacenter == "" {
 				return fmt.Errorf("vsphere-datacenter is required for vSphere. Set the name of the datacenter in which to deploy Kubernetes VMs.")
 			}
-			cluster.Spec.VSphereDatacenter = c.VSphereDatacenter
+			cluster.Spec.CloudConfig.VSphereDatacenter = c.VSphereDatacenter
 
 			if c.VSphereResourcePool == "" {
 				return fmt.Errorf("vsphere-resource-pool is required for vSphere. Set a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs.")
 			}
-			cluster.Spec.VSphereResourcePool = c.VSphereResourcePool
+			cluster.Spec.CloudConfig.VSphereResourcePool = c.VSphereResourcePool
 		}
 	}
 

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -82,6 +82,11 @@ type CreateClusterOptions struct {
 
 	// Egress configuration - FOR TESTING ONLY
 	Egress string
+
+	// vSphere options
+	VSphereServer       string
+	VSphereDatacenter   string
+	VSphereResourcePool string
 }
 
 func (o *CreateClusterOptions) InitDefaults() {
@@ -133,7 +138,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.Target, "target", options.Target, "Target - direct, terraform, cloudformation")
 	cmd.Flags().StringVar(&options.Models, "model", options.Models, "Models to apply (separate multiple models with commas)")
 
-	cmd.Flags().StringVar(&options.Cloud, "cloud", options.Cloud, "Cloud provider to use - gce, aws")
+	cmd.Flags().StringVar(&options.Cloud, "cloud", options.Cloud, "Cloud provider to use - gce, aws, vsphere")
 
 	cmd.Flags().StringSliceVar(&options.Zones, "zones", options.Zones, "Zones in which to run the cluster")
 	cmd.Flags().StringSliceVar(&options.MasterZones, "master-zones", options.MasterZones, "Zones in which to run masters (must be an odd number)")
@@ -181,6 +186,10 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	// Allow custom tags from the CLI
 	cmd.Flags().StringVar(&options.CloudLabels, "cloud-labels", options.CloudLabels, "A list of KV pairs used to tag all instance groups in AWS (eg \"Owner=John Doe,Team=Some Team\").")
 
+	// vSphere flags
+	cmd.Flags().StringVar(&options.VSphereServer, "vsphere-server", options.VSphereServer, "vsphere-server is required for vSphere. Set vCenter URL Ex: 10.192.10.30 or myvcenter.io (without https://)")
+	cmd.Flags().StringVar(&options.VSphereDatacenter, "vsphere-datacenter", options.VSphereDatacenter, "vsphere-datacenter is required for vSphere. Set the name of the datacenter in which to deploy Kubernetes VMs.")
+	cmd.Flags().StringVar(&options.VSphereResourcePool, "vsphere-resource-pool", options.VSphereDatacenter, "vsphere-resource-pool is required for vSphere. Set a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs.")
 	return cmd
 }
 
@@ -472,6 +481,23 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 
 	if c.Cloud != "" {
 		cluster.Spec.CloudProvider = c.Cloud
+
+		if c.Cloud == "vsphere" {
+			if c.VSphereServer == "" {
+				return fmt.Errorf("vsphere-server is required for vSphere. Set vCenter URL Ex: 10.192.10.30 or myvcenter.io (without https://)")
+			}
+			cluster.Spec.VSphereServer = c.VSphereServer
+
+			if c.VSphereDatacenter == "" {
+				return fmt.Errorf("vsphere-datacenter is required for vSphere. Set the name of the datacenter in which to deploy Kubernetes VMs.")
+			}
+			cluster.Spec.VSphereDatacenter = c.VSphereDatacenter
+
+			if c.VSphereResourcePool == "" {
+				return fmt.Errorf("vsphere-resource-pool is required for vSphere. Set a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs.")
+			}
+			cluster.Spec.VSphereResourcePool = c.VSphereResourcePool
+		}
 	}
 
 	if c.Project != "" {

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -241,6 +241,11 @@ type ClusterSpec struct {
 
 	// Tags for AWS instance groups
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
+
+	// vSphere required specs
+	VSphereServer       string
+	VSphereDatacenter   string
+	VSphereResourcePool string
 }
 
 type AccessSpec struct {

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -241,11 +241,6 @@ type ClusterSpec struct {
 
 	// Tags for AWS instance groups
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
-
-	// vSphere required specs
-	VSphereServer       string
-	VSphereDatacenter   string
-	VSphereResourcePool string
 }
 
 type AccessSpec struct {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -653,4 +653,9 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+
+	// vSphere cloud-config specs
+	VSphereServer       string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter   string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool string `json:"vSphereResourcePool,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -649,4 +649,9 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+
+	// vSphere cloud-config specs
+	VSphereServer       string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter   string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool string `json:"vSphereResourcePool,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -275,4 +275,9 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+
+	// vSphere cloud-config specs
+	VSphereServer       string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter   string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool string `json:"vSphereResourcePool,omitempty"`
 }

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -88,6 +88,8 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 				b.addAWSVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
 			case fi.CloudProviderGCE:
 				b.addGCEVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
+			case fi.CloudProviderVSphere:
+				b.addVSphereVolume(c, name, volumeSize, subnet, etcd, m, allMembers)
 			default:
 				return fmt.Errorf("unknown cloudprovider %q", b.Cluster.Spec.CloudProvider)
 			}
@@ -164,4 +166,8 @@ func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, name strin
 	}
 
 	c.AddTask(t)
+}
+
+func (b *MasterVolumeBuilder) addVSphereVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, subnet *kops.ClusterSubnetSpec, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+	fmt.Print("addVSphereVolume to be implemented")
 }

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -365,11 +365,8 @@ func (c *ApplyClusterCmd) Run() error {
 	case fi.CloudProviderVSphere:
 		{
 			vsphereCloud := cloud.(*vsphere.VSphereCloud)
-			region = vsphereCloud.Region
-
-			//if !AlphaAllowGCE.Enabled() {
-			//	return fmt.Errorf("GCE support is currently alpha, and is feature-gated.  export KOPS_FEATURE_FLAGS=AlphaAllowGCE")
-			//}
+			// TODO: map region with vCenter cluster, or datacenter, or datastore?
+			region = vsphereCloud.Cluster
 
 			l.AddTypes(map[string]interface{}{
 				"instance": &vspheretasks.VirtualMachine{},

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -99,8 +99,11 @@ func BuildCloud(cluster *api.Cluster) (fi.Cloud, error) {
 		}
 	case "vsphere":
 		{
-			cloud = &vsphere.VSphereCloud{}
-			fmt.Println("VSphere: In VSphere cloud provider")
+			vsphereCloud, err := vsphere.NewVSphereCloud(&cluster.Spec)
+			if err != nil {
+				return nil, err
+			}
+			cloud = vsphereCloud
 		}
 
 	default:

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -41,11 +41,14 @@ func (c *VSphereCloud) ProviderID() fi.CloudProviderID {
 }
 
 func NewVSphereCloud(spec *kops.ClusterSpec) (*VSphereCloud, error) {
-	server := spec.VSphereServer
-	datacenter := spec.VSphereDatacenter
-	cluster := spec.VSphereResourcePool
+	server := spec.CloudConfig.VSphereServer
+	datacenter := spec.CloudConfig.VSphereDatacenter
+	cluster := spec.CloudConfig.VSphereResourcePool
 	username := os.Getenv("VSPHERE_USERNAME")
 	password := os.Getenv("VSPHERE_PASSWORD")
+	if username == "" || password == "" {
+		return nil, fmt.Errorf("Failed to detect vSphere username and password. Please set env variables: VSPHERE_USERNAME and VSPHERE_PASSWORD accordingly.")
+	}
 
 	c := &VSphereCloud{Server: server, Datacenter: datacenter, Cluster: cluster, Username: username, Password: password}
 	// TODO: create a client of govmomi here?

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -19,21 +19,37 @@ package vsphere
 import (
 	"fmt"
 	"github.com/golang/glog"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 	k8sroute53 "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
+	"os"
 )
 
 type VSphereCloud struct {
-	// dummy field
-	name   string
-	Region string
+	Server     string
+	Datacenter string
+	Cluster    string
+	Username   string
+	Password   string
 }
 
 var _ fi.Cloud = &VSphereCloud{}
 
 func (c *VSphereCloud) ProviderID() fi.CloudProviderID {
 	return fi.CloudProviderVSphere
+}
+
+func NewVSphereCloud(spec *kops.ClusterSpec) (*VSphereCloud, error) {
+	server := spec.VSphereServer
+	datacenter := spec.VSphereDatacenter
+	cluster := spec.VSphereResourcePool
+	username := os.Getenv("VSPHERE_USERNAME")
+	password := os.Getenv("VSPHERE_PASSWORD")
+
+	c := &VSphereCloud{Server: server, Datacenter: datacenter, Cluster: cluster, Username: username, Password: password}
+	// TODO: create a client of govmomi here?
+	return c, nil
 }
 
 func (c *VSphereCloud) DNS() (dnsprovider.Interface, error) {

--- a/upup/pkg/kutil/cluster_resources.go
+++ b/upup/pkg/kutil/cluster_resources.go
@@ -55,6 +55,8 @@ func (c *AwsCluster) ListResources() (map[string]*ResourceTracker, error) {
 		return c.listResourcesAWS()
 	case fi.CloudProviderGCE:
 		return c.listResourcesGCE()
+	case fi.CloudProviderVSphere:
+		return c.listResourcesVSphere()
 	default:
 		return nil, fmt.Errorf("Delete on clusters on %q not (yet) supported", c.Cloud.ProviderID())
 	}

--- a/upup/pkg/kutil/delete_cluster_vsphere.go
+++ b/upup/pkg/kutil/delete_cluster_vsphere.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/upup/pkg/kutil/delete_cluster_vsphere.go
+++ b/upup/pkg/kutil/delete_cluster_vsphere.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kutil
+
+import (
+	"fmt"
+)
+
+func (c *AwsCluster) listResourcesVSphere() (map[string]*ResourceTracker, error) {
+	fmt.Print("listResourcesVSphere to be implemented")
+	return nil, nil
+}


### PR DESCRIPTION
Accept vSphere's server, datacenter, cluster setting by flags
"vsphere-server", "vsphere-datacenter", and "vsphere-resource-pool".
Username and password can be set by environment variables:
"VSPHERE_USERNAME" and "VSPHERE_PASSWORD".

Maybe we will have to give all the vCenter related information in environment variable way.
But now let's use flags for easy testing.