### PR TITLE
Fix the type of vSphere fields in CloudConfig and update auto-generated conversion files.

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -490,17 +490,17 @@ func RunCreateCluster(f *util.Factory, out io.Writer, c *CreateClusterOptions) e
 			if c.VSphereServer == "" {
 				return fmt.Errorf("vsphere-server is required for vSphere. Set vCenter URL Ex: 10.192.10.30 or myvcenter.io (without https://)")
 			}
-			cluster.Spec.CloudConfig.VSphereServer = c.VSphereServer
+			cluster.Spec.CloudConfig.VSphereServer = fi.String(c.VSphereServer)
 
 			if c.VSphereDatacenter == "" {
 				return fmt.Errorf("vsphere-datacenter is required for vSphere. Set the name of the datacenter in which to deploy Kubernetes VMs.")
 			}
-			cluster.Spec.CloudConfig.VSphereDatacenter = c.VSphereDatacenter
+			cluster.Spec.CloudConfig.VSphereDatacenter = fi.String(c.VSphereDatacenter)
 
 			if c.VSphereResourcePool == "" {
 				return fmt.Errorf("vsphere-resource-pool is required for vSphere. Set a valid Cluster, Host or Resource Pool in which to deploy Kubernetes VMs.")
 			}
-			cluster.Spec.CloudConfig.VSphereResourcePool = c.VSphereResourcePool
+			cluster.Spec.CloudConfig.VSphereResourcePool = fi.String(c.VSphereResourcePool)
 		}
 	}
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -655,7 +655,7 @@ type CloudConfiguration struct {
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 
 	// vSphere cloud-config specs
-	VSphereServer       string `json:"vSphereServer,omitempty"`
-	VSphereDatacenter   string `json:"vSphereDatacenter,omitempty"`
-	VSphereResourcePool string `json:"vSphereResourcePool,omitempty"`
+	VSphereServer       *string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter   *string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool *string `json:"vSphereResourcePool,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -651,7 +651,7 @@ type CloudConfiguration struct {
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 
 	// vSphere cloud-config specs
-	VSphereServer       string `json:"vSphereServer,omitempty"`
-	VSphereDatacenter   string `json:"vSphereDatacenter,omitempty"`
-	VSphereResourcePool string `json:"vSphereResourcePool,omitempty"`
+	VSphereServer       *string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter   *string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool *string `json:"vSphereResourcePool,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -226,6 +226,9 @@ func autoConvert_v1alpha1_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.VSphereServer = in.VSphereServer
+	out.VSphereDatacenter = in.VSphereDatacenter
+	out.VSphereResourcePool = in.VSphereResourcePool
 	return nil
 }
 
@@ -237,6 +240,9 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha1_CloudConfiguration(in *kops
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.VSphereServer = in.VSphereServer
+	out.VSphereDatacenter = in.VSphereDatacenter
+	out.VSphereResourcePool = in.VSphereResourcePool
 	return nil
 }
 
@@ -1250,6 +1256,8 @@ func Convert_kops_KubeSchedulerConfig_To_v1alpha1_KubeSchedulerConfig(in *kops.K
 
 func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *KubeletConfigSpec, out *kops.KubeletConfigSpec, s conversion.Scope) error {
 	out.APIServers = in.APIServers
+	out.KubeconfigPath = in.KubeconfigPath
+	out.RequireKubeconfig = in.RequireKubeconfig
 	out.LogLevel = in.LogLevel
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
@@ -1293,6 +1301,8 @@ func Convert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *KubeletCon
 
 func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.KubeletConfigSpec, out *KubeletConfigSpec, s conversion.Scope) error {
 	out.APIServers = in.APIServers
+	out.KubeconfigPath = in.KubeconfigPath
+	out.RequireKubeconfig = in.RequireKubeconfig
 	out.LogLevel = in.LogLevel
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -277,7 +277,7 @@ type CloudConfiguration struct {
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
 
 	// vSphere cloud-config specs
-	VSphereServer       string `json:"vSphereServer,omitempty"`
-	VSphereDatacenter   string `json:"vSphereDatacenter,omitempty"`
-	VSphereResourcePool string `json:"vSphereResourcePool,omitempty"`
+	VSphereServer       *string `json:"vSphereServer,omitempty"`
+	VSphereDatacenter   *string `json:"vSphereDatacenter,omitempty"`
+	VSphereResourcePool *string `json:"vSphereResourcePool,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -252,6 +252,9 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.VSphereServer = in.VSphereServer
+	out.VSphereDatacenter = in.VSphereDatacenter
+	out.VSphereResourcePool = in.VSphereResourcePool
 	return nil
 }
 
@@ -263,6 +266,9 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha2_CloudConfiguration(in *kops
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.VSphereServer = in.VSphereServer
+	out.VSphereDatacenter = in.VSphereDatacenter
+	out.VSphereResourcePool = in.VSphereResourcePool
 	return nil
 }
 
@@ -1348,6 +1354,8 @@ func Convert_kops_KubeSchedulerConfig_To_v1alpha2_KubeSchedulerConfig(in *kops.K
 
 func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *KubeletConfigSpec, out *kops.KubeletConfigSpec, s conversion.Scope) error {
 	out.APIServers = in.APIServers
+	out.KubeconfigPath = in.KubeconfigPath
+	out.RequireKubeconfig = in.RequireKubeconfig
 	out.LogLevel = in.LogLevel
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride
@@ -1391,6 +1399,8 @@ func Convert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *KubeletCon
 
 func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.KubeletConfigSpec, out *KubeletConfigSpec, s conversion.Scope) error {
 	out.APIServers = in.APIServers
+	out.KubeconfigPath = in.KubeconfigPath
+	out.RequireKubeconfig = in.RequireKubeconfig
 	out.LogLevel = in.LogLevel
 	out.PodManifestPath = in.PodManifestPath
 	out.HostnameOverride = in.HostnameOverride

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -637,6 +637,8 @@ func (c *ApplyClusterCmd) Run() error {
 			target = gce.NewGCEAPITarget(cloud.(*gce.GCECloud))
 		case "aws":
 			target = awsup.NewAWSAPITarget(cloud.(awsup.AWSCloud))
+		case "vsphere":
+			target = vsphere.NewVSphereAPITarget(cloud.(*vsphere.VSphereCloud))
 		default:
 			return fmt.Errorf("direct configuration not supported with CloudProvider:%q", cluster.Spec.CloudProvider)
 		}

--- a/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
+++ b/upup/pkg/fi/cloudup/vsphere/vsphere_cloud.go
@@ -41,9 +41,9 @@ func (c *VSphereCloud) ProviderID() fi.CloudProviderID {
 }
 
 func NewVSphereCloud(spec *kops.ClusterSpec) (*VSphereCloud, error) {
-	server := spec.CloudConfig.VSphereServer
-	datacenter := spec.CloudConfig.VSphereDatacenter
-	cluster := spec.CloudConfig.VSphereResourcePool
+	server := *spec.CloudConfig.VSphereServer
+	datacenter := *spec.CloudConfig.VSphereDatacenter
+	cluster := *spec.CloudConfig.VSphereResourcePool
 	username := os.Getenv("VSPHERE_USERNAME")
 	password := os.Getenv("VSPHERE_PASSWORD")
 	if username == "" || password == "" {


### PR DESCRIPTION
To make sure the vSphere fields in CloudConfiguration can be successfully serialized
and output into config file.