### PR TITLE
Add vSphere volumes to protokube. Update vSphere testing doc and make…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ all: kops
 
 .PHONY: channels examples
 
-#DOCKER_REGISTRY?=gcr.io/must-override
-DOCKER_REGISTRY=prashima
+DOCKER_REGISTRY?=gcr.io/must-override
 S3_BUCKET?=s3://must-override/
 GCS_LOCATION?=gs://must-override
 GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ all: kops
 
 .PHONY: channels examples
 
-DOCKER_REGISTRY?=gcr.io/must-override
+#DOCKER_REGISTRY?=gcr.io/must-override
+DOCKER_REGISTRY=prashima
 S3_BUCKET?=s3://must-override/
 GCS_LOCATION?=gs://must-override
 GCS_URL=$(GCS_LOCATION:gs://%=https://storage.googleapis.com/%)
@@ -189,6 +190,11 @@ push-gce-run: push
 push-aws-run: push
 	ssh -t ${TARGET} sudo SKIP_PACKAGE_UPDATE=1 /tmp/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --v=8
 
+# Please read docs/development/vsphere-dev.md before trying this out.
+# Build protokube and nodeup. Pushes protokube to DOCKER_REGISTRY and scp nodeup binary to the TARGET. Uncomment ssh part to run nodeup at set TARGET.
+push-vsphere: nodeup protokube-push
+	scp -C .build/dist/nodeup  ${TARGET}:~/
+	# ssh -t root@10.161.56.108 'export AWS_ACCESS_KEY_ID="AKIAJ6UOKB6BGYLIQJEQ"; export AWS_SECRET_ACCESS_KEY="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"; export AWS_REGION="us-west-2"; SKIP_PACKAGE_UPDATE=1 ~/nodeup --conf=/var/cache/kubernetes-install/kube_env.yaml --v=8'
 
 protokube-gocode:
 	go install k8s.io/kops/protokube/cmd/protokube

--- a/docs/development/vsphere-dev.md
+++ b/docs/development/vsphere-dev.md
@@ -1,0 +1,86 @@
+# Development process and hacks for vSphere
+
+This document contains few details, guidelines and tips about ongoing effort for vSphere support for kops.
+
+## Contact
+We are using [#sig-onprem channel](https://kubernetes.slack.com/messages/sig-onprem/) for discussing vSphere support for kops. Please feel free to join and talk to us.
+
+## Process
+Here is a [list of requirements and tasks](https://docs.google.com/document/d/10L7I98GuW7o7QuX_1QTouxC0t0aEO_68uHKNc7o4fXY/edit#heading=h.6wyer21z75n9 "Kops-vSphere specification") that we are working on. Once the basic infrastructure for vSphere is ready, we will move these tasks to issues.
+
+## Hacks
+
+### Nodeup and protokube testing
+This Section talks about testing nodeup and protokube changes on a standalone VM, running on standalone esx or vSphere.
+
+#### Pre-requisites
+Following manual steps are pre-requisites for this testing, until vSphere support for kops starts to create this infrastructure.
+
++ Setup password free ssh to the VM
+```bash
+cat ~/.ssh/id_rsa.pub | ssh <username>@<vm_ip> 'cat >> .ssh/authorized_keys'
+```
++ Nodeup configuration file needs to be present on the VM. It can be copied from an existing AWS created master (or worker, whichever you are testing), from this location /var/cache/kubernetes-install/kube_env.yaml on your existing cluster node. Sample nodeup cofiguation file-
+ ```yaml
+Assets:
+- 5e486d4a2700a3a61c4edfd97fb088984a7f734f@https://storage.googleapis.com/kubernetes-release/release/v1.5.2/bin/linux/amd64/kubelet
+- 10e675883b167140f78ddf7ed92f936dca291647@https://storage.googleapis.com/kubernetes-release/release/v1.5.2/bin/linux/amd64/kubectl
+- 19d49f7b2b99cd2493d5ae0ace896c64e289ccbb@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+ClusterName: cluster3.mangoreviews.com
+ConfigBase: s3://your-objectstore/cluster1.yourdomain.com
+InstanceGroupName: master-us-west-2a
+Tags:
+- _automatic_upgrades
+- _aws
+- _cni_bridge
+- _cni_host_local
+- _cni_loopback
+- _cni_ptp
+- _kubernetes_master
+- _kubernetes_pool
+- _protokube
+channels:
+- s3://your-objectstore/cluster1.yourdomain.com/addons/bootstrap-channel.yaml
+protokubeImage:
+  hash: 6805cba0ea13805b2fa439914679a083be7ac959
+  name: protokube:1.5.1
+  source: https://kubeupv2.s3.amazonaws.com/kops/1.5.1/images/protokube.tar.gz
+
+ ```
++ Currently vSphere code is using AWS S3 for storing all configurations, spec, etc. You need valid AWS credentials.
++ s3://your-objectstore/cluster1.yourdomain.com folder should have all necessary configuration, spec, addons, etc. (If you don't know how to get this, then read more on kops and how to deploy a cluster using kops)
+
+#### Testing your changes
+Once you are done making your changes in nodeup and protokube code, you would want to test them on a VM. In order to do so you will need to build nodeup binary and copy it on the desired VM. You would also want to modify nodeup code so that it accesses protokube container image that contains your changes. All this can be done by setting few environment variables, minor code updates and running 'make push-vsphere'.
+
+ + Create or use existing docker hub registry to create 'protokube' repo for your custom image. Update the registry details in Makefile, by modifying DOCKER_REGISTRY variable. Don't forget to do 'docker login' with your registry credentials once.
+ + Export TARGET environment variable, setting its value to username@vm_ip of your test VM.
+ + Update $KOPS_DIR/upup/models/nodeup/_protokube/services/protokube.service.template-
+ ```
+ ExecStart=/usr/bin/docker run -v /:/rootfs/ -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --net=host --privileged -e AWS_ACCESS_KEY_ID='something' -e AWS_SECRET_ACCESS_KEY='something'  <your-registry>/protokube:<image-tag> /usr/bin/protokube "$DAEMON_ARGS"
+ ```
++ Run 'make push-vsphere'. This will build nodeup binary, scp it to your test VM, build protokube image and upload it to your registry.
++ SSH to your test VM and set following environment variables-
+  ```bash
+  export AWS_REGION=us-west-2
+  export AWS_ACCESS_KEY_ID=something
+  export AWS_SECRET_ACCESS_KEY=something
+  ```
++ Run './nodeup --conf kube_env.yaml' to test your custom build nodeup and protokube.
+
+**Tip:** Consider adding following code to $KOPS_DIR/upup/pkg/fi/nodeup/nodetasks/load_image.go to avoid downloading protokube image. Your custom image will be downloaded directly when systemd will run protokube.service (because of the changes we made in protokube.service.template).
+ ```go
+ 	// Add this after url variable has been populated.
+ 	if strings.Contains(url, "protokube") {
+ 		fmt.Println("Skipping protokube image download and loading.")
+ 		return nil
+ 	}
+ ```
+
+
+ **Note:** Same testing can also be done using alternate steps (these steps are _not working_ currently due to hash match failure):
+  + Run 'make protokube-export' and 'make nodeup' to build and export protokube image as tar.gz, and to build nodeup binary. Both located in $KOPS_DIR/.build/dist/images/protokube.tar.gz and $KOPS_DIR/.build/dist/nodeup, respectively.
+  + Copy nodeup binary to the test VM.
+  + Upload $KOPS_DIR/.build/dist/images/protokube.tar.gz and $KOPS_DIR/.build/dist/images/protokube.tar.gz.sha1, with appropriate permissions, to a location from where it can be accessed from the test VM. Eg: your development machine's public_html, if working on linux based machine.
+  + Update hash value to protokube.tar.gz.sha1's value and source to the uploaded location, in kube_env.yaml (see pre-requisite steps).
+  + SSH to your test VM, set necessary environment variables and run './nodeup --conf kube_env.yaml'.

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -120,6 +120,17 @@ func run() error {
 		if internalIP == nil {
 			internalIP = gceVolumes.InternalIP()
 		}
+	} else if cloud == "vsphere" {
+		fmt.Println("Initializing vSphere volumes")
+		vsphereVolumes, err := protokube.NewVSphereVolumes()
+		if err != nil {
+			glog.Errorf("Error initializing vSphere: %q", err)
+		}
+		volumes = vsphereVolumes
+		if internalIP == nil {
+			internalIP = vsphereVolumes.InternalIp()
+		}
+
 	} else {
 		glog.Errorf("Unknown cloud %q", cloud)
 		os.Exit(1)
@@ -188,7 +199,7 @@ func run() error {
 	}
 
 	rootfs := "/"
-	if containerized {
+	if containerized && cloud != "vsphere" {
 		rootfs = "/rootfs/"
 	}
 	protokube.RootFS = rootfs

--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -121,10 +121,11 @@ func run() error {
 			internalIP = gceVolumes.InternalIP()
 		}
 	} else if cloud == "vsphere" {
-		fmt.Println("Initializing vSphere volumes")
+		glog.Info("Initializing vSphere volumes")
 		vsphereVolumes, err := protokube.NewVSphereVolumes()
 		if err != nil {
 			glog.Errorf("Error initializing vSphere: %q", err)
+			os.Exit(1)
 		}
 		volumes = vsphereVolumes
 		if internalIP == nil {
@@ -199,7 +200,7 @@ func run() error {
 	}
 
 	rootfs := "/"
-	if containerized && cloud != "vsphere" {
+	if containerized {
 		rootfs = "/rootfs/"
 	}
 	protokube.RootFS = rootfs

--- a/protokube/pkg/protokube/vsphere_volume.go
+++ b/protokube/pkg/protokube/vsphere_volume.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protokube
+
+import (
+	"github.com/golang/glog"
+	"net"
+)
+
+const EtcdDataKey = "01"
+const EtcdDataVolPath = "/mnt/master-" + EtcdDataKey
+const EtcdEventKey = "02"
+const EtcdEventVolPath = "/mnt/master-" + EtcdEventKey
+
+// TODO Use lsblk or counterpart command to find the actual device details.
+const LocalDeviceForDataVol = "/dev/sdb1"
+const LocalDeviceForEventsVol = "/dev/sdc1"
+const AttachedToValue = "localhost"
+const VolStatusValue = "attached"
+const EtcdNodeName = "a"
+const EtcdClusterName = "main"
+const EtcdEventsClusterName = "events"
+
+type VSphereVolumes struct {
+	paths map[string]string
+}
+
+var _ Volumes = &VSphereVolumes{}
+
+func NewVSphereVolumes() (*VSphereVolumes, error) {
+	vsphereVolumes := &VSphereVolumes{
+		paths: make(map[string]string),
+	}
+	vsphereVolumes.paths[EtcdDataKey] = EtcdDataVolPath
+	//vsphereVolumes.paths[EtcdEventKey] = EtcdEventVolPath
+	glog.Infof("Created new VSphereVolumes instance.")
+	return vsphereVolumes, nil
+}
+
+func (v *VSphereVolumes) FindVolumes() ([]*Volume, error) {
+	var volumes []*Volume
+	// etcd data volume and etcd cluster spec.
+	{
+		vol := &Volume{
+			ID:          EtcdDataKey,
+			LocalDevice: LocalDeviceForDataVol,
+			AttachedTo:  AttachedToValue,
+			Mountpoint:  EtcdDataVolPath,
+			Status:      VolStatusValue,
+			Info: VolumeInfo{
+				Description: EtcdClusterName,
+			},
+		}
+		etcdSpec := &EtcdClusterSpec{
+			ClusterKey: EtcdClusterName,
+			NodeName:   EtcdNodeName,
+			NodeNames:  []string{EtcdNodeName},
+		}
+		vol.Info.EtcdClusters = []*EtcdClusterSpec{etcdSpec}
+		volumes = append(volumes, vol)
+	}
+
+	// etcd events volume and etcd events cluster spec.
+	{
+		vol := &Volume{
+			ID:          EtcdEventKey,
+			LocalDevice: LocalDeviceForEventsVol,
+			AttachedTo:  AttachedToValue,
+			Mountpoint:  EtcdEventVolPath,
+			Status:      VolStatusValue,
+			Info: VolumeInfo{
+				Description: EtcdEventsClusterName,
+			},
+		}
+		etcdSpec := &EtcdClusterSpec{
+			ClusterKey: EtcdEventsClusterName,
+			NodeName:   EtcdNodeName,
+			NodeNames:  []string{EtcdNodeName},
+		}
+		vol.Info.EtcdClusters = []*EtcdClusterSpec{etcdSpec}
+		volumes = append(volumes, vol)
+	}
+	glog.Infof("Found volumes: %v", volumes)
+	return volumes, nil
+}
+
+func (v *VSphereVolumes) AttachVolume(volume *Volume) error {
+	// Currently this is a no-op for vSphere. The virtual disks should already be mounted on this VM.
+	glog.Infof("All volumes should already be attached. No operation done.")
+	return nil
+}
+
+func (v *VSphereVolumes) InternalIp() net.IP {
+	ipStr := "127.0.0.1"
+	ip := net.ParseIP(ipStr)
+	return ip
+}

--- a/upup/pkg/fi/nodeup/protokube_flags.go
+++ b/upup/pkg/fi/nodeup/protokube_flags.go
@@ -29,4 +29,5 @@ type ProtokubeFlags struct {
 
 	DNSInternalSuffix *string `json:"dnsInternalSuffix,omitempty" flag:"dns-internal-suffix"`
 	Cloud             *string `json:"cloud,omitempty" flag:"cloud"`
+	ClusterId         *string `json:"cluster-id,omitempty" flag:"cluster-id"`
 }

--- a/upup/pkg/fi/nodeup/protokube_flags.go
+++ b/upup/pkg/fi/nodeup/protokube_flags.go
@@ -29,5 +29,6 @@ type ProtokubeFlags struct {
 
 	DNSInternalSuffix *string `json:"dnsInternalSuffix,omitempty" flag:"dns-internal-suffix"`
 	Cloud             *string `json:"cloud,omitempty" flag:"cloud"`
-	ClusterId         *string `json:"cluster-id,omitempty" flag:"cluster-id"`
+	// ClusterId flag is required only for vSphere cloud type, to pass cluster id information to protokube. AWS and GCE workflows ignore this flag.
+	ClusterId *string `json:"cluster-id,omitempty" flag:"cluster-id"`
 }

--- a/upup/pkg/fi/nodeup/template_functions.go
+++ b/upup/pkg/fi/nodeup/template_functions.go
@@ -274,6 +274,7 @@ func (t *templateFunctions) ProtokubeFlags() *ProtokubeFlags {
 			f.DNSProvider = fi.String("google-clouddns")
 		case fi.CloudProviderVSphere:
 			f.DNSProvider = fi.String("aws-route53")
+			f.ClusterId = fi.String(t.cluster.ObjectMeta.Name)
 		default:
 			glog.Warningf("Unknown cloudprovider %q; won't set DNS provider")
 		}


### PR DESCRIPTION
Changes:
1. Added vsphere_volume to handle static volumes for vSphere VM and update protokube/main.go to identify vSphere cloud.
2. Added cluster-id flag in protokube flags and populating it for vSphere, in order to pass cluster name to protokube.
3. Added make file target to help build and push nodeup and protokube binary/image in vSphere VM and docker registery, respectively.
4. Added doc for vSphere related development and hacks for nodeup and protokube testing.

Testing:
1. Successfully ran make for 'ci' and 'push-vsphere' targets.
2. Manual testing of nodeup and protokube binaries on standalone vSphere VM.

Safety:
These changes are not being executed for any workflows for any cloud providers, unless tried explicitly by updating cluster.spec and executing nodeup.

With these changes 2 statically mounted disks on vSphere VMs can be used by protokube for etcd data and etcd event storage purpose. End-to-end kubernetes configuration is not working on standalone VM for following reasons:
- Error while applying master taints: Eg: 'kube_boot.go:117] error updating master taints: error querying nodes: Get http://localhost:8080/api/v1/nodes?labelSelector=kubernetes.io%2Frole%3Dmaster: dial tcp [::1]:8080: getsockopt: connection refused'
- Code is not able to access various namespaces. Eg: 'error querying namespace "kube-system": Get http://localhost:8080/api/v1/namespaces/kube-system: dial tcp [::1]:8080: getsockopt: connection refused'